### PR TITLE
📦 infra: Dockerfile.dev — dev build environment (task t_74291f5b)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,16 @@
+# POA dev/test image — host Ruby (Steam Deck) cannot build native gems
+# (missing /usr/include/stdio.h). Build: sg docker -c 'docker build -f Dockerfile.dev -t poa-dev:local .'
+# Run:   sg docker -c 'docker run --rm -v "$PWD:/app" -w /app poa-dev:local ./bin/build'
+FROM ruby:3.4
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV BUNDLE_PATH=/bundle
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .


### PR DESCRIPTION
TASK: t_74291f5b (Setup projektu POA)
BASE: 1ad875a
HEAD: 4cf58a5d384d40e83d59bec9aa9be0f7f8d85195

ZAKRES: nowy plik Dockerfile.dev (ruby:3.4 + build-essential, BUNDLE_PATH=/bundle, bundle install w obrazie).

DLACZEGO: host (Steam Deck) nie może instalować gemów z C-extension — brak /usr/include/stdio.h (Bundler::GemNotFound: bigdecimal-4.1.2). Wszystkie buildy POA idą przez kontener poa-dev:local.

WERYFIKACJA: 
- docker build -f Dockerfile.dev -t poa-dev:local . — OK (sha256:326df8a4)
- docker run --rm -v $PWD:/app -w /app poa-dev:local ./bin/build — OK, build deterministyczny (git status czysty, 0 diffów w build/)

HANDOFF: reviewer — sprawdź plik i dowody powyżej; niezależnie przebuduj jeśli trzeba.