### PR TITLE
🔧 infra: add .dockerignore (follow-up F2 from PR #25 review)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Keep the docker build context lean: no VCS metadata, generated output,
+# secrets, or nested worktree checkouts.
+.git
+build
+.worktrees
+.env


### PR DESCRIPTION
Task: t_10d3f478 (board poa)

## Goal
Build context of `docker build -f Dockerfile.dev` must not carry .git/, build/, .worktrees/ or a potential .env. Follow-up F2 flagged in independent review of PR #25 (Dockerfile.dev), registered in skill poa-project 2026-08-07.

## Changes
- New `.dockerignore` with 4 entries: `.git`, `build`, `.worktrees`, `.env`.
- `.worktrees` added beyond the review note (.git/build/.env): nested worktree checkouts live inside the repo dir (e.g. `/home/deck/Programowanie/POA/.worktrees/*`) and are the same class of context noise. Reviewer decides.

## Verification (local, poa-dev:local container)
- Build context: 25.90MB without .dockerignore → 7.42MB with it (−71%).
- `./bin/build` in container: OK, deterministic — 198 files, md5 0 diffs across 2 builds.
- Output identical to live site (style.css?v=e562dec06d, same as https://aikido-polska.eu/).
- No code/content/style changes — site content untouched.

## Risk
Low. POA has no secrets/.env; build/ is generated in CI. Merge will re-run gh-pages deploy with identical content.