### PR TITLE
🔧 fix: kopiuj app.js do build/ — 404 na produkcji

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,4 +1,5 @@
 {
   "style.css": "style.css",
+  "app.js": "app.js",
   "images/toyoda.svg": "images/toyoda.svg"
 }

--- a/lib/site/generate.rb
+++ b/lib/site/generate.rb
@@ -189,6 +189,7 @@ PAGES = {
       FileUtils.cp_r File.join(root, "assets/images"), File.join(export_dir, "assets/images")
       FileUtils.cp_r File.join(root, "assets/favicons/."), File.join(export_dir)
       FileUtils.cp File.join(root, "assets/style.css"), File.join(export_dir, "assets/style.css")
+      FileUtils.cp File.join(root, "assets/app.js"), File.join(export_dir, "assets/app.js")
       FileUtils.cp File.join(root, "assets/manifest.json"), File.join(export_dir, "assets/manifest.json")
       FileUtils.cp File.join(root, "assets/robots.txt"), File.join(export_dir, "robots.txt")
 

--- a/test/determinism_test.rb
+++ b/test/determinism_test.rb
@@ -93,7 +93,7 @@ class DeterminismTest < Minitest::Test
          .map { |f| "assets/images/#{f.sub(%r{\A#{Regexp.escape(images_root)}/}, "")}" }
     )
     expected.concat Dir.glob(File.join(root, "assets/favicons", "*")).map { |f| File.basename(f) }
-    expected.concat %w[assets/style.css assets/manifest.json robots.txt .nojekyll CNAME]
+    expected.concat %w[assets/style.css assets/app.js assets/manifest.json robots.txt .nojekyll CNAME]
 
     assert_equal expected.sort, actual.sort,
                  "build output diverged from snapshot page set or asset copy rules " \


### PR DESCRIPTION
## Task
Card: t_7ab6bdbd — app.js nie kopiowany do build/ → 404 na produkcji

## Problem
Oba layouty (site.html.erb:134, site_en.html.erb:134) renderują `/assets/app.js?v=be2214590c` przez `asset_path_with_version('app.js')`, ale `Generate#copy_static_assets` (lib/site/generate.rb) kopiował tylko style.css/images/favicons/manifest/robots/.nojekyll/CNAME. Efekt: `https://aikido-polska.eu/assets/app.js` → HTTP 404 (potwierdzone curl 2026-08-08), scroll-progress bar i back-to-top nie działają na produkcji.

## Fix (3 pliki, +3/-1)
1. `lib/site/generate.rb` — `FileUtils.cp assets/app.js → build/assets/app.js` (wzorzec jak style.css)
2. `assets/manifest.json` — wpis `app.js` (spójność z `Precompiled#[]`)
3. `test/determinism_test.rb` — oracle asset copy rules: +assets/app.js (kontrakt snapshotu: update razem ze zmianą)

## Weryfikacja
- Build w poa-dev:local: exit 0; `build/assets/app.js` istnieje
- `bin/test`: **50 runs, 266 assertions, 0 failures** (determinizm 2× build identyczny)
- Diff drzewa build vs master: **tylko** `assets/app.js` (nowy) + `assets/manifest.json` (wpis) — zero zmian HTML, zero zmian digestów (content-based)
- base: `aa46add8` (master), head: `1b07979d`

## Review
Prośba o niezależny GO/NO-GO.